### PR TITLE
restore(links): tombstone the 20 old skill URLs so inbound links stop 404ing

### DIFF
--- a/build/geo-content-optimizer/SKILL.md
+++ b/build/geo-content-optimizer/SKILL.md
@@ -1,0 +1,17 @@
+# `geo-content-optimizer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `build/geo-content-optimizer/` keep resolving.
+
+**Active version:** [`seo-geo/build/geo-content-optimizer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/build/geo-content-optimizer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`build/geo-content-optimizer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/build/geo-content-optimizer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s geo-content-optimizer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/build/meta-tags-optimizer/SKILL.md
+++ b/build/meta-tags-optimizer/SKILL.md
@@ -1,0 +1,18 @@
+# `meta-tags-optimizer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `build/meta-tags-optimizer/` keep resolving.
+
+**Active version:** [`seo-geo/build/serp-markup-builder`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/build/serp-markup-builder) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `meta-tags-optimizer` was merged into `serp-markup-builder` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`build/meta-tags-optimizer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/build/meta-tags-optimizer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s serp-markup-builder
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/build/schema-markup-generator/SKILL.md
+++ b/build/schema-markup-generator/SKILL.md
@@ -1,0 +1,18 @@
+# `schema-markup-generator` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `build/schema-markup-generator/` keep resolving.
+
+**Active version:** [`seo-geo/build/serp-markup-builder`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/build/serp-markup-builder) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `schema-markup-generator` was merged into `serp-markup-builder` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`build/schema-markup-generator/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/build/schema-markup-generator/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s serp-markup-builder
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/build/seo-content-writer/SKILL.md
+++ b/build/seo-content-writer/SKILL.md
@@ -1,0 +1,18 @@
+# `seo-content-writer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `build/seo-content-writer/` keep resolving.
+
+**Active version:** [`seo-geo/build/content-writer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/build/content-writer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `seo-content-writer` was merged into `content-writer` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`build/seo-content-writer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/build/seo-content-writer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s content-writer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/cross-cutting/content-quality-auditor/SKILL.md
+++ b/cross-cutting/content-quality-auditor/SKILL.md
@@ -1,0 +1,17 @@
+# `content-quality-auditor` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `cross-cutting/content-quality-auditor/` keep resolving.
+
+**Active version:** [`seo-geo/optimize/content-quality-auditor`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/optimize/content-quality-auditor) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`cross-cutting/content-quality-auditor/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/cross-cutting/content-quality-auditor/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s content-quality-auditor
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/cross-cutting/domain-authority-auditor/SKILL.md
+++ b/cross-cutting/domain-authority-auditor/SKILL.md
@@ -1,0 +1,17 @@
+# `domain-authority-auditor` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `cross-cutting/domain-authority-auditor/` keep resolving.
+
+**Active version:** [`seo-geo/monitor/domain-authority-auditor`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/monitor/domain-authority-auditor) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`cross-cutting/domain-authority-auditor/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/cross-cutting/domain-authority-auditor/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s domain-authority-auditor
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/cross-cutting/entity-optimizer/SKILL.md
+++ b/cross-cutting/entity-optimizer/SKILL.md
@@ -1,0 +1,17 @@
+# `entity-optimizer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `cross-cutting/entity-optimizer/` keep resolving.
+
+**Active version:** [`protocol/entity-optimizer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/protocol/entity-optimizer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`cross-cutting/entity-optimizer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/cross-cutting/entity-optimizer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s entity-optimizer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/cross-cutting/memory-management/SKILL.md
+++ b/cross-cutting/memory-management/SKILL.md
@@ -1,0 +1,17 @@
+# `memory-management` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `cross-cutting/memory-management/` keep resolving.
+
+**Active version:** [`protocol/memory-management`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/protocol/memory-management) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`cross-cutting/memory-management/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/cross-cutting/memory-management/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s memory-management
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/monitor/alert-manager/SKILL.md
+++ b/monitor/alert-manager/SKILL.md
@@ -1,0 +1,18 @@
+# `alert-manager` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `monitor/alert-manager/` keep resolving.
+
+**Active version:** [`seo-geo/monitor/performance-monitor`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/monitor/performance-monitor) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `alert-manager` was merged into `performance-monitor` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`monitor/alert-manager/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/monitor/alert-manager/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s performance-monitor
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/monitor/backlink-analyzer/SKILL.md
+++ b/monitor/backlink-analyzer/SKILL.md
@@ -1,0 +1,18 @@
+# `backlink-analyzer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `monitor/backlink-analyzer/` keep resolving.
+
+**Active version:** [`seo-geo/monitor/offsite-signal-analyzer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/monitor/offsite-signal-analyzer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `backlink-analyzer` was merged into `offsite-signal-analyzer` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`monitor/backlink-analyzer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/monitor/backlink-analyzer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s offsite-signal-analyzer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/monitor/performance-reporter/SKILL.md
+++ b/monitor/performance-reporter/SKILL.md
@@ -1,0 +1,18 @@
+# `performance-reporter` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `monitor/performance-reporter/` keep resolving.
+
+**Active version:** [`seo-geo/monitor/performance-monitor`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/monitor/performance-monitor) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `performance-reporter` was merged into `performance-monitor` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`monitor/performance-reporter/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/monitor/performance-reporter/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s performance-monitor
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/monitor/rank-tracker/SKILL.md
+++ b/monitor/rank-tracker/SKILL.md
@@ -1,0 +1,17 @@
+# `rank-tracker` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `monitor/rank-tracker/` keep resolving.
+
+**Active version:** [`seo-geo/monitor/rank-tracker`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/monitor/rank-tracker) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`monitor/rank-tracker/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/monitor/rank-tracker/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s rank-tracker
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/optimize/content-refresher/SKILL.md
+++ b/optimize/content-refresher/SKILL.md
@@ -1,0 +1,18 @@
+# `content-refresher` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `optimize/content-refresher/` keep resolving.
+
+**Active version:** [`seo-geo/build/content-writer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/build/content-writer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `content-refresher` was merged into `content-writer` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`optimize/content-refresher/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/optimize/content-refresher/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s content-writer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/optimize/internal-linking-optimizer/SKILL.md
+++ b/optimize/internal-linking-optimizer/SKILL.md
@@ -1,0 +1,18 @@
+# `internal-linking-optimizer` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `optimize/internal-linking-optimizer/` keep resolving.
+
+**Active version:** [`seo-geo/optimize/site-structure-optimizer`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/optimize/site-structure-optimizer) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+_The old `internal-linking-optimizer` was merged into `site-structure-optimizer` — see the mapping table for what folded where._
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`optimize/internal-linking-optimizer/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/optimize/internal-linking-optimizer/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s site-structure-optimizer
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/optimize/on-page-seo-auditor/SKILL.md
+++ b/optimize/on-page-seo-auditor/SKILL.md
@@ -1,0 +1,17 @@
+# `on-page-seo-auditor` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `optimize/on-page-seo-auditor/` keep resolving.
+
+**Active version:** [`seo-geo/optimize/on-page-seo-auditor`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/optimize/on-page-seo-auditor) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`optimize/on-page-seo-auditor/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/optimize/on-page-seo-auditor/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s on-page-seo-auditor
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/optimize/technical-seo-checker/SKILL.md
+++ b/optimize/technical-seo-checker/SKILL.md
@@ -1,0 +1,17 @@
+# `technical-seo-checker` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `optimize/technical-seo-checker/` keep resolving.
+
+**Active version:** [`seo-geo/optimize/technical-seo-checker`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/optimize/technical-seo-checker) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`optimize/technical-seo-checker/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/optimize/technical-seo-checker/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s technical-seo-checker
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/research/competitor-analysis/SKILL.md
+++ b/research/competitor-analysis/SKILL.md
@@ -1,0 +1,17 @@
+# `competitor-analysis` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `research/competitor-analysis/` keep resolving.
+
+**Active version:** [`seo-geo/research/competitor-analysis`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/research/competitor-analysis) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`research/competitor-analysis/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/research/competitor-analysis/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s competitor-analysis
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/research/content-gap-analysis/SKILL.md
+++ b/research/content-gap-analysis/SKILL.md
@@ -1,0 +1,17 @@
+# `content-gap-analysis` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `research/content-gap-analysis/` keep resolving.
+
+**Active version:** [`seo-geo/research/content-gap-analysis`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/research/content-gap-analysis) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`research/content-gap-analysis/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/research/content-gap-analysis/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s content-gap-analysis
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/research/keyword-research/SKILL.md
+++ b/research/keyword-research/SKILL.md
@@ -1,0 +1,17 @@
+# `keyword-research` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `research/keyword-research/` keep resolving.
+
+**Active version:** [`seo-geo/research/keyword-research`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/research/keyword-research) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`research/keyword-research/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/research/keyword-research/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s keyword-research
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).

--- a/research/serp-analysis/SKILL.md
+++ b/research/serp-analysis/SKILL.md
@@ -1,0 +1,17 @@
+# `serp-analysis` has moved
+
+> [!IMPORTANT]
+> `seo-geo-claude-skills` is now a **signpost** repo — its skills are no longer developed here.
+> This file exists only so older links to `research/serp-analysis/` keep resolving.
+
+**Active version:** [`seo-geo/research/serp-analysis`](https://github.com/aaron-he-zhu/aaron-marketing-skills/tree/main/seo-geo/research/serp-analysis) in the [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) bundle.
+
+**Frozen standalone copy** (unchanged, tag `v9.9.12`): [`research/serp-analysis/SKILL.md`](https://github.com/aaron-he-zhu/seo-geo-claude-skills/blob/v9.9.12/research/serp-analysis/SKILL.md).
+
+Install the active skill from the bundle:
+
+```
+npx skills add aaron-he-zhu/aaron-marketing-skills -s serp-analysis
+```
+
+Full 20 → 16 mapping: see the repo [README](https://github.com/aaron-he-zhu/seo-geo-claude-skills#readme).


### PR DESCRIPTION
## Why
When this repo became a signpost, the 20 standalone skill directories were deleted. Any external inbound link to an old skill path now **404s**, e.g.:

- `…/tree/main/research/keyword-research`
- `…/blob/main/build/seo-content-writer/SKILL.md`

GitHub can't server-side-redirect file paths, so the only way to keep those URLs alive is to put a file back at each path.

## What
Restores all 20 original directories, each with a small **"has moved"** `SKILL.md` tombstone that links:
- the **active version** in [`aaron-marketing-skills`](https://github.com/aaron-he-zhu/aaron-marketing-skills) (direct, or "merged into X" where the skill was folded), and
- the **frozen v9.9.12 copy** of the exact old file.

This revives both URL shapes external links use — the directory (`…/tree/main/<path>`) and the file (`…/blob/main/<path>/SKILL.md`).

The stubs carry **no valid skill frontmatter**, so `npx skills` / Claude Code won't treat them as installable skills — they exist purely to keep links resolving. The signpost README's 20→16 mapping table is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)